### PR TITLE
Update the import page function to convert page content to markdown and handle confluence page format

### DIFF
--- a/components/BookmarkPanel.tsx
+++ b/components/BookmarkPanel.tsx
@@ -15,6 +15,7 @@ import {
   ChevronUp,
   X,
   Upload,
+  FileText,
 } from 'lucide-react';
 import type { ImportProgress } from '@/lib/types';
 import type { BookmarkItem } from '@/services/bookmarks';
@@ -26,6 +27,7 @@ interface Props {
 }
 
 type PanelState = 'idle' | 'loading' | 'importing' | 'exporting' | 'success' | 'error';
+type CaptureState = 'idle' | 'capturing';
 
 export function BookmarkPanel({ onProgress }: Props) {
   const [bookmarks, setBookmarks] = useState<BookmarkItem[]>([]);
@@ -33,6 +35,7 @@ export function BookmarkPanel({ onProgress }: Props) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [activeCollection, setActiveCollection] = useState<string>('all');
   const [state, setState] = useState<PanelState>('idle');
+  const [captureState, setCaptureState] = useState<CaptureState>('idle');
   const [error, setError] = useState('');
   const [currentTabInfo, setCurrentTabInfo] = useState<{ url: string; title: string; favicon?: string } | null>(null);
   const [isCurrentBookmarked, setIsCurrentBookmarked] = useState(false);
@@ -164,6 +167,21 @@ export function BookmarkPanel({ onProgress }: Props) {
     });
   };
 
+  const handleCaptureContent = () => {
+    setCaptureState('capturing');
+    setError('');
+    chrome.runtime.sendMessage({ type: 'CAPTURE_PAGE_CONTENT' }, (resp) => {
+      setCaptureState('idle');
+      if (resp?.success) {
+        setState('success');
+        setTimeout(() => setState('idle'), 2000);
+      } else {
+        setError(resp?.error || t('single.captureFailedHint'));
+        setState('error');
+      }
+    });
+  };
+
   const handleImportToNotebookLM = () => {
     const items = filteredBookmarks.filter((b) => selectedIds.has(b.id));
     if (items.length === 0) return;
@@ -261,11 +279,20 @@ export function BookmarkPanel({ onProgress }: Props) {
                 );
                 setState('importing');
               }}
-              disabled={state === 'importing'}
+              disabled={state === 'importing' || captureState === 'capturing'}
               className="btn-press flex items-center gap-1 px-3 py-1.5 bg-amber-500 text-white text-xs rounded-md hover:bg-amber-600 transition-colors shadow-btn hover:shadow-btn-hover transition-all duration-150"
             >
               {state === 'importing' ? <Loader2 className="w-3 h-3 animate-spin" /> : <Upload className="w-3 h-3" />}
               {t('bookmark.importNow')}
+            </button>
+            <button
+              onClick={handleCaptureContent}
+              disabled={state === 'importing' || captureState === 'capturing' || !currentTabInfo?.url?.startsWith('http')}
+              title={!currentTabInfo?.url?.startsWith('http') ? t('single.captureNotSupported') : t('single.captureAuthHint')}
+              className="btn-press flex items-center gap-1 px-3 py-1.5 bg-gray-600 text-white text-xs rounded-md hover:bg-gray-700 transition-colors shadow-btn hover:shadow-btn-hover transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {captureState === 'capturing' ? <Loader2 className="w-3 h-3 animate-spin" /> : <FileText className="w-3 h-3" />}
+              {t('single.captureContent')}
             </button>
           </div>
         </div>

--- a/components/ImportPanel.tsx
+++ b/components/ImportPanel.tsx
@@ -37,6 +37,7 @@ export function ImportPanel({ onProgress }: Props) {
   const [selectedArticles, setSelectedArticles] = useState<Set<string>>(new Set());
   const [currentTabUrl, setCurrentTabUrl] = useState<string | null>(null);
   const [state, setState] = useState<ImportState>('idle');
+  const [captureState, setCaptureState] = useState<'idle' | 'capturing'>('idle');
   const [error, setError] = useState('');
   const [importResults, setImportResults] = useState<ImportItem[] | null>(null);
   const [showDetails, setShowDetails] = useState(false);
@@ -89,6 +90,22 @@ export function ImportPanel({ onProgress }: Props) {
       } else {
         setState('error');
         setError(response?.error || t('single.importFailedHint'));
+      }
+    });
+  };
+
+  // ── Page Content Capture ──
+  const handleCaptureContent = () => {
+    setCaptureState('capturing');
+    setError('');
+    chrome.runtime.sendMessage({ type: 'CAPTURE_PAGE_CONTENT' }, (response) => {
+      setCaptureState('idle');
+      if (response?.success) {
+        setState('success');
+        setTimeout(() => setState('idle'), 3000);
+      } else {
+        setState('error');
+        setError(response?.error || t('single.captureFailedHint'));
       }
     });
   };
@@ -232,11 +249,20 @@ export function ImportPanel({ onProgress }: Props) {
                 <span className="flex-1 text-sm text-gray-700 truncate">{currentTabUrl}</span>
                 <button
                   onClick={() => { setUrl(currentTabUrl); handleSingleImport(currentTabUrl); }}
-                  disabled={state === 'importing'}
+                  disabled={state === 'importing' || captureState === 'capturing'}
                   className="px-3 py-1.5 bg-notebooklm-blue text-white text-xs rounded-md hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
                 >
                   {state === 'importing' ? <Loader2 className="w-3 h-3 animate-spin" /> : <ExternalLink className="w-3 h-3" />}
                   {t('import')}
+                </button>
+                <button
+                  onClick={handleCaptureContent}
+                  disabled={state === 'importing' || captureState === 'capturing' || !currentTabUrl?.startsWith('http')}
+                  title={!currentTabUrl?.startsWith('http') ? t('single.captureNotSupported') : t('single.captureAuthHint')}
+                  className="px-3 py-1.5 bg-gray-600 text-white text-xs rounded-md hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+                >
+                  {captureState === 'capturing' ? <Loader2 className="w-3 h-3 animate-spin" /> : <FileText className="w-3 h-3" />}
+                  {t('single.captureContent')}
                 </button>
               </div>
             </div>

--- a/components/SingleImport.tsx
+++ b/components/SingleImport.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, Loader2, CheckCircle, AlertCircle, ExternalLink } from 'lucide-react';
+import { Link, Loader2, CheckCircle, AlertCircle, ExternalLink, FileText } from 'lucide-react';
 import type { ImportProgress } from '@/lib/types';
 import { isValidUrl } from '@/lib/utils';
 import { t } from '@/lib/i18n';
@@ -8,7 +8,7 @@ interface Props {
   onProgress: (progress: ImportProgress | null) => void;
 }
 
-type ImportState = 'idle' | 'loading' | 'importing' | 'success' | 'error';
+type ImportState = 'idle' | 'loading' | 'importing' | 'capturing' | 'success' | 'error';
 
 export function SingleImport({ onProgress }: Props) {
   const [url, setUrl] = useState('');
@@ -61,6 +61,24 @@ export function SingleImport({ onProgress }: Props) {
     }
   };
 
+  const handleCaptureContent = () => {
+    setState('capturing');
+    setError('');
+
+    chrome.runtime.sendMessage({ type: 'CAPTURE_PAGE_CONTENT' }, (response) => {
+      if (response?.success) {
+        setState('success');
+        setTimeout(() => setState('idle'), 3000);
+      } else {
+        setState('error');
+        setError(response?.error || t('single.captureFailedHint'));
+      }
+    });
+  };
+
+  const isCapturableUrl = currentTabUrl?.startsWith('http');
+  const isBusy = state === 'importing' || state === 'capturing';
+
   return (
     <div className="space-y-4">
       {/* Current tab quick import */}
@@ -71,7 +89,7 @@ export function SingleImport({ onProgress }: Props) {
             <span className="flex-1 text-sm text-gray-700 truncate">{currentTabUrl}</span>
             <button
               onClick={handleImportCurrentTab}
-              disabled={state === 'importing'}
+              disabled={isBusy}
               className="px-3 py-1.5 bg-notebooklm-blue text-white text-xs rounded-md hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
             >
               {state === 'importing' ? (
@@ -80,6 +98,19 @@ export function SingleImport({ onProgress }: Props) {
                 <ExternalLink className="w-3 h-3" />
               )}
               {t('import')}
+            </button>
+            <button
+              onClick={handleCaptureContent}
+              disabled={isBusy || !isCapturableUrl}
+              title={!isCapturableUrl ? t('single.captureNotSupported') : t('single.captureAuthHint')}
+              className="px-3 py-1.5 bg-gray-600 text-white text-xs rounded-md hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+            >
+              {state === 'capturing' ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <FileText className="w-3 h-3" />
+              )}
+              {t('single.captureContent')}
             </button>
           </div>
         </div>
@@ -101,7 +132,7 @@ export function SingleImport({ onProgress }: Props) {
           </div>
           <button
             onClick={() => handleImport(url)}
-            disabled={!url || state === 'importing'}
+            disabled={!url || isBusy}
             className="px-4 py-2 bg-notebooklm-blue text-white text-sm rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           >
             {state === 'importing' ? (
@@ -138,6 +169,7 @@ export function SingleImport({ onProgress }: Props) {
           <li>{t('single.webArticles')}</li>
           <li>{t('single.substackWechat')}</li>
           <li>{t('single.pdfLinks')}</li>
+          <li>{t('single.captureAuthHint')}</li>
         </ul>
       </div>
     </div>

--- a/components/SingleImport.tsx
+++ b/components/SingleImport.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link, Loader2, CheckCircle, AlertCircle, ExternalLink, FileText } from 'lucide-react';
 import type { ImportProgress } from '@/lib/types';
 import { isValidUrl } from '@/lib/utils';
@@ -17,13 +17,13 @@ export function SingleImport({ onProgress }: Props) {
   const [error, setError] = useState('');
 
   // Load current tab URL on mount
-  useState(() => {
+  useEffect(() => {
     chrome.runtime.sendMessage({ type: 'GET_CURRENT_TAB' }, (response) => {
       if (response?.success && response.data) {
         setCurrentTabUrl(response.data as string);
       }
     });
-  });
+  }, []);
 
   const handleImport = async (targetUrl: string) => {
     if (!isValidUrl(targetUrl)) {

--- a/docs/superpowers/plans/2026-03-29-page-content-capture.md
+++ b/docs/superpowers/plans/2026-03-29-page-content-capture.md
@@ -1,0 +1,646 @@
+# Page Content Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an "Import Page Content" button to the SingleImport component that captures the current tab's DOM, converts it to Markdown, and imports it into NotebookLM — enabling import of authenticated pages that NotebookLM's servers cannot access.
+
+**Architecture:** The popup sends a `CAPTURE_PAGE_CONTENT` message to the background; the background injects an inline script via `chrome.scripting.executeScript()` to extract `document.body.innerHTML` and `document.title` from the active tab; the HTML is converted to Markdown via the existing offscreen document; then imported via the existing `importText()` service.
+
+**Tech Stack:** TypeScript, React, Chrome Extension MV3, Turndown (HTML→Markdown), Vitest
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|--------------|
+| `lib/types.ts` | Modify | Add `CAPTURE_PAGE_CONTENT` to `MessageType` |
+| `lib/i18n.ts` | Modify | Add i18n strings for the new button and error messages |
+| `entrypoints/offscreen/main.ts` | Modify | Add < 200 char fallback in `htmlToMarkdown()` |
+| `entrypoints/background.ts` | Modify | Add `case 'CAPTURE_PAGE_CONTENT'` in `handleMessage()` |
+| `components/SingleImport.tsx` | Modify | Add "Import Page Content" button |
+| `tests/offscreen-page-capture.test.ts` | Create | Unit tests for offscreen fallback logic |
+| `tests/services/page-capture.test.ts` | Create | Unit tests for background handler logic |
+
+---
+
+## Task 1: Add type and i18n strings
+
+**Files:**
+- Modify: `lib/types.ts`
+- Modify: `lib/i18n.ts`
+
+- [ ] **Step 1: Add message type to `lib/types.ts`**
+
+In `lib/types.ts`, add the new entry to the `MessageType` union after `| { type: 'IMPORT_BATCH'; urls: string[] }` (line 82):
+
+```typescript
+  | { type: 'CAPTURE_PAGE_CONTENT' }
+```
+
+So the block looks like:
+```typescript
+export type MessageType =
+  | { type: 'IMPORT_URL'; url: string }
+  | { type: 'IMPORT_BATCH'; urls: string[] }
+  | { type: 'CAPTURE_PAGE_CONTENT' }
+  // ... rest unchanged
+```
+
+- [ ] **Step 2: Add i18n strings to `lib/i18n.ts`**
+
+In the `zh` object, in the `// ── SingleImport ──` section (after line 163), add:
+```typescript
+  'single.captureContent': '导入页面内容',
+  'single.capturingBtn': '捕获中',
+  'single.captureFailedHint': '页面内容捕获失败，请确保页面已完全加载',
+  'single.captureNotSupported': '无法捕获此类页面',
+  'single.captureAuthHint': '适用于需要登录的内部页面（Confluence、企业 Wiki 等）',
+```
+
+In the `en` object, in the `// ── SingleImport ──` section (after line 443), add:
+```typescript
+  'single.captureContent': 'Import Page Content',
+  'single.capturingBtn': 'Capturing',
+  'single.captureFailedHint': 'Failed to capture page content. Make sure the page is fully loaded.',
+  'single.captureNotSupported': 'Cannot capture this page type',
+  'single.captureAuthHint': 'Use for pages requiring login (Confluence, internal wikis, etc.)',
+```
+
+- [ ] **Step 3: Run TypeScript check**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm compile
+```
+
+Expected: no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/types.ts lib/i18n.ts
+git commit -m "feat: add CAPTURE_PAGE_CONTENT type and i18n strings"
+```
+
+---
+
+## Task 2: Update offscreen htmlToMarkdown with smart/fallback threshold
+
+**Files:**
+- Modify: `entrypoints/offscreen/main.ts:124-160`
+- Create: `tests/offscreen-page-capture.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/offscreen-page-capture.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+// We test the fallback logic by extracting htmlToMarkdown into a testable form.
+// Since the offscreen module runs in a Chrome context, we reproduce the pure logic here.
+
+import TurndownService from 'turndown';
+
+const CONTENT_SELECTORS = [
+  '.devsite-article-body',
+  '.doc-content', '.document-content',
+  '.available-content .body.markup', '.available-content', '.body.markup',
+  '.markdown-body',
+  'article [itemprop="articleBody"]',
+  'article', 'main', '[role="main"]', '#content', '.prose', '.content',
+];
+
+const REMOVE_SELECTORS = [
+  'script', 'style', 'nav', 'footer', 'header',
+  '.sidebar', '.toc', '.breadcrumb',
+].join(',');
+
+function htmlToMarkdownWithFallback(html: string): { markdown: string; title: string } {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+
+  let el: Element | null = null;
+  for (const s of CONTENT_SELECTORS) {
+    el = doc.querySelector(s);
+    if (el) break;
+  }
+  if (!el) el = doc.body;
+
+  // Fallback: if smart extraction yields < 200 chars, use full body
+  const smartText = el.textContent?.trim() || '';
+  if (smartText.length < 200 && el !== doc.body) {
+    el = doc.body;
+  }
+
+  el.querySelectorAll(REMOVE_SELECTORS).forEach(e => e.remove());
+
+  const title = doc.querySelector('h1')?.textContent?.trim() || doc.title || '';
+  const td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced', bulletListMarker: '-' });
+  const markdown = td.turndown(el.innerHTML).replace(/\n{3,}/g, '\n\n').trim();
+
+  return { markdown, title };
+}
+
+describe('htmlToMarkdown fallback logic', () => {
+  it('uses smart selector when content is >= 200 chars', () => {
+    const longText = 'a'.repeat(300);
+    const html = `<html><body>
+      <nav>Navigation</nav>
+      <article>${longText}</article>
+    </body></html>`;
+    const { markdown } = htmlToMarkdownWithFallback(html);
+    // Should use <article> content only, nav stripped
+    expect(markdown).toContain('a'.repeat(200));
+    expect(markdown).not.toContain('Navigation');
+  });
+
+  it('falls back to full body when smart selector yields < 200 chars', () => {
+    const html = `<html><body>
+      <article>Short.</article>
+      <div class="sidebar-content">This is extra content outside article that should appear in fallback mode with plenty of text to confirm fallback works correctly here and now.</div>
+    </body></html>`;
+    const { markdown } = htmlToMarkdownWithFallback(html);
+    // Should include the sidebar div since fallback uses body
+    expect(markdown).toContain('extra content outside article');
+  });
+
+  it('uses body directly when no selector matches', () => {
+    const html = `<html><title>My Page</title><body><p>Hello world content that is quite short</p></body></html>`;
+    const { markdown } = htmlToMarkdownWithFallback(html);
+    expect(markdown).toContain('Hello world');
+  });
+
+  it('extracts title from h1', () => {
+    const html = `<html><body><article><h1>My Title</h1>${'content '.repeat(50)}</article></body></html>`;
+    const { title } = htmlToMarkdownWithFallback(html);
+    expect(title).toBe('My Title');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm test tests/offscreen-page-capture.test.ts
+```
+
+Expected: tests fail because `htmlToMarkdownWithFallback` is defined locally in the test and should pass — but confirms the logic before applying it to the offscreen module.
+
+> **Note:** The tests are self-contained (they define the logic locally). They will actually PASS already since the logic is correct. The purpose is to lock in the expected behavior before modifying the production file. Proceed to Step 3.
+
+- [ ] **Step 3: Update `entrypoints/offscreen/main.ts` — add fallback threshold**
+
+In `entrypoints/offscreen/main.ts`, replace lines 128–133 (the content selector loop and `if (!el)` fallback):
+
+**Before:**
+```typescript
+  let el: Element | null = null;
+  for (const s of CONTENT_SELECTORS) {
+    el = doc.querySelector(s);
+    if (el) break;
+  }
+  if (!el) el = doc.body;
+```
+
+**After:**
+```typescript
+  let el: Element | null = null;
+  for (const s of CONTENT_SELECTORS) {
+    el = doc.querySelector(s);
+    if (el) break;
+  }
+  if (!el) el = doc.body;
+
+  // Fallback: if smart extraction yields < 200 chars, use full body
+  const smartText = el.textContent?.trim() || '';
+  if (smartText.length < 200 && el !== doc.body) {
+    el = doc.body;
+  }
+```
+
+- [ ] **Step 4: Run TypeScript check**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm compile
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm test tests/offscreen-page-capture.test.ts
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add entrypoints/offscreen/main.ts tests/offscreen-page-capture.test.ts
+git commit -m "feat: add smart/fallback threshold in htmlToMarkdown (< 200 chars falls back to body)"
+```
+
+---
+
+## Task 3: Add CAPTURE_PAGE_CONTENT handler in background
+
+**Files:**
+- Modify: `entrypoints/background.ts`
+- Create: `tests/services/page-capture.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/page-capture.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We test the handler logic by extracting it into a testable helper.
+// The actual case in background.ts calls the same pattern.
+
+async function capturePageContent(
+  tabId: number,
+  tabUrl: string,
+  executeScript: (opts: { target: { tabId: number }; func: () => { html: string; title: string } }) => Promise<Array<{ result: { html: string; title: string } }>>,
+  convertHtmlToMarkdown: (html: string) => Promise<{ markdown: string; title: string }>,
+  importText: (text: string, title: string, senderTabId?: number) => Promise<boolean>,
+  senderTabId?: number
+): Promise<boolean> {
+  if (!tabUrl.startsWith('http')) {
+    throw new Error('Cannot capture this page type');
+  }
+  let extracted: { html: string; title: string };
+  try {
+    const result = await executeScript({ target: { tabId }, func: () => ({ html: document.body.innerHTML, title: document.title }) });
+    extracted = result[0].result;
+  } catch {
+    throw new Error('Could not capture this page type');
+  }
+  const { markdown, title } = await convertHtmlToMarkdown(extracted.html);
+  const pageTitle = extracted.title || title;
+  const success = await importText(markdown, pageTitle, senderTabId);
+  if (!success) throw new Error('Import failed');
+  return true;
+}
+
+describe('capturePageContent', () => {
+  const mockExecuteScript = vi.fn();
+  const mockConvert = vi.fn();
+  const mockImport = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('extracts HTML from tab, converts to markdown, and imports', async () => {
+    mockExecuteScript.mockResolvedValue([{ result: { html: '<p>Hello</p>', title: 'My Page' } }]);
+    mockConvert.mockResolvedValue({ markdown: '# Hello', title: 'My Page' });
+    mockImport.mockResolvedValue(true);
+
+    const result = await capturePageContent(42, 'https://example.com', mockExecuteScript, mockConvert, mockImport, 1);
+
+    expect(result).toBe(true);
+    expect(mockExecuteScript).toHaveBeenCalledWith(expect.objectContaining({ target: { tabId: 42 } }));
+    expect(mockConvert).toHaveBeenCalledWith('<p>Hello</p>');
+    expect(mockImport).toHaveBeenCalledWith('# Hello', 'My Page', 1);
+  });
+
+  it('throws for non-http URLs', async () => {
+    await expect(
+      capturePageContent(1, 'chrome://extensions', mockExecuteScript, mockConvert, mockImport)
+    ).rejects.toThrow('Cannot capture this page type');
+    expect(mockExecuteScript).not.toHaveBeenCalled();
+  });
+
+  it('throws when executeScript fails (restricted tab)', async () => {
+    mockExecuteScript.mockRejectedValue(new Error('Cannot access a chrome extension URL'));
+    await expect(
+      capturePageContent(1, 'https://example.com', mockExecuteScript, mockConvert, mockImport)
+    ).rejects.toThrow('Could not capture this page type');
+  });
+
+  it('throws when importText returns false', async () => {
+    mockExecuteScript.mockResolvedValue([{ result: { html: '<p>x</p>', title: 'T' } }]);
+    mockConvert.mockResolvedValue({ markdown: 'x', title: 'T' });
+    mockImport.mockResolvedValue(false);
+
+    await expect(
+      capturePageContent(1, 'https://example.com', mockExecuteScript, mockConvert, mockImport)
+    ).rejects.toThrow('Import failed');
+  });
+
+  it('uses tab title when markdown title is empty', async () => {
+    mockExecuteScript.mockResolvedValue([{ result: { html: '<p>content</p>', title: 'Tab Title' } }]);
+    mockConvert.mockResolvedValue({ markdown: 'content', title: '' });
+    mockImport.mockResolvedValue(true);
+
+    await capturePageContent(1, 'https://example.com', mockExecuteScript, mockConvert, mockImport);
+    expect(mockImport).toHaveBeenCalledWith('content', 'Tab Title', undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes (logic is in test)**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm test tests/services/page-capture.test.ts
+```
+
+Expected: all 5 tests pass (logic defined inline in test file).
+
+- [ ] **Step 3: Add the handler in `entrypoints/background.ts`**
+
+In `entrypoints/background.ts`, find the `handleMessage` switch. Locate:
+```typescript
+    case 'IMPORT_URL':
+      return await importUrl(message.url, senderTabId);
+
+    case 'IMPORT_BATCH':
+```
+
+Add the new case before `case 'IMPORT_URL':`:
+```typescript
+    case 'CAPTURE_PAGE_CONTENT': {
+      const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (!activeTab?.id) throw new Error('No active tab found');
+      const tabUrl = activeTab.url || '';
+      if (!tabUrl.startsWith('http')) throw new Error('Cannot capture this page type');
+
+      let extracted: { html: string; title: string };
+      try {
+        const results = await chrome.scripting.executeScript({
+          target: { tabId: activeTab.id },
+          func: () => ({ html: document.body.innerHTML, title: document.title }),
+        });
+        extracted = results[0].result;
+      } catch {
+        throw new Error('Could not capture this page type');
+      }
+
+      const { markdown, title } = await convertHtmlToMarkdown(extracted.html);
+      const pageTitle = extracted.title || title;
+      const success = await importText(markdown, pageTitle, senderTabId);
+      if (!success) throw new Error('Import failed. Make sure NotebookLM is open.');
+      return true;
+    }
+
+    case 'IMPORT_URL':
+```
+
+- [ ] **Step 4: Run TypeScript check**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm compile
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add entrypoints/background.ts tests/services/page-capture.test.ts
+git commit -m "feat: add CAPTURE_PAGE_CONTENT handler in background service worker"
+```
+
+---
+
+## Task 4: Add "Import Page Content" button to SingleImport UI
+
+**Files:**
+- Modify: `components/SingleImport.tsx`
+
+- [ ] **Step 1: Update `components/SingleImport.tsx`**
+
+Replace the entire file content with:
+
+```tsx
+import { useState } from 'react';
+import { Link, Loader2, CheckCircle, AlertCircle, ExternalLink, FileText } from 'lucide-react';
+import type { ImportProgress } from '@/lib/types';
+import { isValidUrl } from '@/lib/utils';
+import { t } from '@/lib/i18n';
+
+interface Props {
+  onProgress: (progress: ImportProgress | null) => void;
+}
+
+type ImportState = 'idle' | 'loading' | 'importing' | 'capturing' | 'success' | 'error';
+
+export function SingleImport({ onProgress }: Props) {
+  const [url, setUrl] = useState('');
+  const [currentTabUrl, setCurrentTabUrl] = useState<string | null>(null);
+  const [state, setState] = useState<ImportState>('idle');
+  const [error, setError] = useState('');
+
+  // Load current tab URL on mount
+  useState(() => {
+    chrome.runtime.sendMessage({ type: 'GET_CURRENT_TAB' }, (response) => {
+      if (response?.success && response.data) {
+        setCurrentTabUrl(response.data as string);
+      }
+    });
+  });
+
+  const handleImport = async (targetUrl: string) => {
+    if (!isValidUrl(targetUrl)) {
+      setError(t('invalidUrl'));
+      setState('error');
+      return;
+    }
+
+    setState('importing');
+    setError('');
+
+    onProgress({
+      total: 1,
+      completed: 0,
+      items: [{ url: targetUrl, status: 'importing' }],
+    });
+
+    chrome.runtime.sendMessage({ type: 'IMPORT_URL', url: targetUrl }, (response) => {
+      onProgress(null);
+
+      if (response?.success && response.data) {
+        setState('success');
+        setTimeout(() => setState('idle'), 3000);
+      } else {
+        setState('error');
+        setError(response?.error || t('single.importFailedHint'));
+      }
+    });
+  };
+
+  const handleImportCurrentTab = () => {
+    if (currentTabUrl) {
+      setUrl(currentTabUrl);
+      handleImport(currentTabUrl);
+    }
+  };
+
+  const handleCaptureContent = () => {
+    setState('capturing');
+    setError('');
+
+    chrome.runtime.sendMessage({ type: 'CAPTURE_PAGE_CONTENT' }, (response) => {
+      if (response?.success) {
+        setState('success');
+        setTimeout(() => setState('idle'), 3000);
+      } else {
+        setState('error');
+        setError(response?.error || t('single.captureFailedHint'));
+      }
+    });
+  };
+
+  const isCapturableUrl = currentTabUrl?.startsWith('http');
+  const isBusy = state === 'importing' || state === 'capturing';
+
+  return (
+    <div className="space-y-4">
+      {/* Current tab quick import */}
+      {currentTabUrl && (
+        <div className="bg-gray-50 rounded-lg p-3">
+          <p className="text-xs text-gray-500 mb-2">{t('single.currentTab')}</p>
+          <div className="flex items-center gap-2">
+            <span className="flex-1 text-sm text-gray-700 truncate">{currentTabUrl}</span>
+            <button
+              onClick={handleImportCurrentTab}
+              disabled={isBusy}
+              className="px-3 py-1.5 bg-notebooklm-blue text-white text-xs rounded-md hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+            >
+              {state === 'importing' ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <ExternalLink className="w-3 h-3" />
+              )}
+              {t('import')}
+            </button>
+            <button
+              onClick={handleCaptureContent}
+              disabled={isBusy || !isCapturableUrl}
+              title={!isCapturableUrl ? t('single.captureNotSupported') : t('single.captureAuthHint')}
+              className="px-3 py-1.5 bg-gray-600 text-white text-xs rounded-md hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+            >
+              {state === 'capturing' ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <FileText className="w-3 h-3" />
+              )}
+              {t('single.captureContent')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Manual URL input */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">{t('single.enterUrl')}</label>
+        <div className="flex gap-2">
+          <div className="flex-1 relative">
+            <Link className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://example.com/article"
+              className="w-full pl-10 pr-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-notebooklm-blue focus:border-transparent"
+            />
+          </div>
+          <button
+            onClick={() => handleImport(url)}
+            disabled={!url || isBusy}
+            className="px-4 py-2 bg-notebooklm-blue text-white text-sm rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {state === 'importing' ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                {t('single.importingBtn')}
+              </>
+            ) : (
+              t('import')
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Status messages */}
+      {state === 'success' && (
+        <div className="flex items-center gap-2 text-green-600 text-sm bg-green-50 rounded-lg p-3">
+          <CheckCircle className="w-4 h-4" />
+          {t('importSuccess')}
+        </div>
+      )}
+
+      {state === 'error' && (
+        <div className="flex items-center gap-2 text-red-500 text-sm bg-red-50 rounded-lg p-3">
+          <AlertCircle className="w-4 h-4" />
+          {error}
+        </div>
+      )}
+
+      {/* Tips */}
+      <div className="text-xs text-gray-400 space-y-1">
+        <p>{t('single.supportedImports')}</p>
+        <ul className="list-disc list-inside space-y-0.5 text-gray-400">
+          <li>{t('single.webArticles')}</li>
+          <li>{t('single.substackWechat')}</li>
+          <li>{t('single.pdfLinks')}</li>
+          <li>{t('single.captureAuthHint')}</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run TypeScript check**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm compile
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Build to verify no bundle errors**
+
+```bash
+cd /home/tongdu/code/notebooklm-jetpack && pnpm build
+```
+
+Expected: build succeeds, `dist/` produced.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/SingleImport.tsx
+git commit -m "feat: add Import Page Content button to SingleImport for authenticated pages"
+```
+
+---
+
+## Manual Verification Checklist
+
+After building, load `dist/` as unpacked extension in Chrome, then verify:
+
+1. Open `https://example.com` → popup More tab → "Import Page Content" button is visible
+2. Open `chrome://extensions` → "Import Page Content" button is disabled with tooltip
+3. Click "Import Page Content" on a regular page → spinner appears → success or error shown
+4. Open a Confluence page (or other auth-required page) → "Import Page Content" captures and imports content
+5. Both "Import" (URL) and "Import Page Content" buttons are correctly disabled while the other is busy

--- a/docs/superpowers/specs/2026-03-29-page-content-capture-design.md
+++ b/docs/superpowers/specs/2026-03-29-page-content-capture-design.md
@@ -1,0 +1,98 @@
+# Page Content Capture — Design Spec
+
+**Date:** 2026-03-29
+**Status:** Approved
+**Feature area:** URL / Page Import
+
+---
+
+## Problem
+
+The existing "Import URL" feature passes URLs directly to NotebookLM, which fetches them server-side. This fails for any page requiring authentication — internal Confluence wikis, corporate intranets, staging environments, or any private site. NotebookLM's servers cannot access authenticated pages.
+
+## Goal
+
+Add an explicit "Import Page Content" button that captures the DOM of the currently open tab (as the user sees it), converts it to Markdown, and imports it into NotebookLM via the "Copied text" path — bypassing the authentication problem entirely.
+
+---
+
+## Architecture
+
+### New Message Type
+
+Add to `lib/types.ts` `MessageType` union:
+
+```typescript
+CAPTURE_PAGE_CONTENT: { tabId: number }
+```
+
+### Data Flow
+
+```
+User clicks "Import Page Content" (popup)
+  → sends CAPTURE_PAGE_CONTENT { tabId } to background
+  → background: chrome.scripting.executeScript() inline function on the tab
+      returns: { html: document.body.innerHTML, title: document.title }
+  → background: sends HTML to offscreen document via HTML_TO_MARKDOWN
+      offscreen: smart selector extraction
+        → if result < 200 chars → full body fallback
+        → Turndown HTML→Markdown conversion
+  → background: calls importTextToNotebookLM(markdown, title)
+      via existing IMPORT_TEXT message path
+  → returns { success, error? } to popup
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `lib/types.ts` | Add `CAPTURE_PAGE_CONTENT` to `MessageType` |
+| `entrypoints/background.ts` | Handle `CAPTURE_PAGE_CONTENT`: inject inline script, call offscreen, call importText |
+| `entrypoints/offscreen/main.ts` | Minor: expose full-body fallback when smart extraction yields < 200 chars |
+| `components/SingleImport.tsx` | Add "Import Page Content" button with loading/error state |
+
+No new content script files. No new service files.
+
+---
+
+## UI Changes
+
+**Location:** More panel → `SingleImport` component (existing)
+
+**Change:** Add a secondary "Import Page Content" button below the existing "Import" (URL) button.
+
+- Displays the current tab URL as a read-only context label (shared with existing button)
+- Disabled on non-`http/https` pages (chrome://, file://, etc.) with a tooltip: "Cannot capture browser internal pages"
+- Shares the same loading/error state UI as the existing import button
+- On success: same confirmation feedback as URL import
+
+---
+
+## Content Extraction
+
+The offscreen document's `htmlToMarkdown()` already implements a two-stage approach that is reused here:
+
+1. **Smart extraction:** Try known content CSS selectors (`article`, `main`, `.markdown-body`, `.doc-content`, etc.) in priority order; strip navs, footers, sidebars
+2. **Full-body fallback:** If smart extraction yields < 200 characters, fall back to `document.body` — nothing gets missed
+
+The page `<title>` is used as the NotebookLM source title, auto-populated with no user editing step.
+
+---
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| `chrome://` or `file://` pages | Button disabled; tooltip: "Cannot capture browser internal pages" |
+| `chrome.scripting.executeScript()` throws (PDF viewer, restricted tab) | Return error to popup: "Could not capture this page type" |
+| Smart extraction + fallback both yield very short content | Import as-is; user can judge the result |
+| Very long pages | No truncation; import full content. NotebookLM handles large "Copied text" inputs |
+| Offscreen conversion failure | Bubble error back to popup with message |
+
+---
+
+## Out of Scope
+
+- Batch capture of multiple tabs (existing batch import continues to use URL-only)
+- Capturing pages from an arbitrary URL (only the currently active tab)
+- Any modification to the Docs, Podcast, YouTube, or AI Chat import flows

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -165,8 +165,6 @@ try {
 } catch { /* fake-browser in WXT build doesn't support onMessageExternal */ }
 
 // Context menu IDs
-const MENU_ID_PAGE = 'import-page';
-const MENU_ID_LINK = 'import-link';
 const MENU_ID_CAPTURE = 'capture-page-content';
 
 export default defineBackground(() => {
@@ -179,24 +177,10 @@ export default defineBackground(() => {
       chrome.tabs.create({ url: chrome.runtime.getURL('/welcome.html') });
     }
 
-    // Menu item for importing current page
-    chrome.contextMenus.create({
-      id: MENU_ID_PAGE,
-      title: '导入此页面到 NotebookLM',
-      contexts: ['page'],
-    });
-
-    // Menu item for importing a link
-    chrome.contextMenus.create({
-      id: MENU_ID_LINK,
-      title: '导入此链接到 NotebookLM',
-      contexts: ['link'],
-    });
-
     // Menu item for capturing page content (for authenticated pages)
     chrome.contextMenus.create({
       id: MENU_ID_CAPTURE,
-      title: '导入此页面内容到 NotebookLM（适用于需登录页面）',
+      title: '导入此页面内容到 NotebookLM',
       contexts: ['page'],
     });
   });
@@ -221,24 +205,6 @@ export default defineBackground(() => {
         console.error('Context menu capture failed:', error);
       }
       return;
-    }
-
-    let url: string | undefined;
-    if (info.menuItemId === MENU_ID_PAGE) {
-      url = tab?.url;
-    } else if (info.menuItemId === MENU_ID_LINK) {
-      url = info.linkUrl;
-    }
-
-    if (!url || !url.startsWith('http')) {
-      console.warn('Context menu import: invalid URL');
-      return;
-    }
-
-    try {
-      await importUrl(url);
-    } catch (error) {
-      console.error('Context menu import failed:', error);
     }
   });
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -201,7 +201,8 @@ export default defineBackground(() => {
         const { html, title: tabTitle } = results[0].result;
         const { markdown, title } = await convertHtmlToMarkdown(html);
         const pageTitle = tabTitle || title;
-        const contentWithHeader = `# [${pageTitle}](${tab.url})\n\n${markdown}`;
+        const headerTitle = title || tabTitle;
+        const contentWithHeader = `${headerTitle}\n${tab.url}\n\n${markdown}`;
         await importText(contentWithHeader, pageTitle);
       } catch (error) {
         console.error('Context menu capture failed:', error);
@@ -932,11 +933,10 @@ async function handleMessage(message: MessageType, senderTabId?: number): Promis
       }
 
       const { markdown, title } = await convertHtmlToMarkdown(extracted.html);
-      // Use h1-derived title for the header link (clean), document.title for the source name
       const pageTitle = extracted.title || title;
       const headerTitle = title || extracted.title;
-      const contentWithHeader = `# [${headerTitle}](${tabUrl})\n\n${markdown}`;
-      console.log('[CAPTURE] header:', contentWithHeader.slice(0, 120));
+      // Use plain text format — NotebookLM strips markdown # headings from pasted text
+      const contentWithHeader = `${headerTitle}\n${tabUrl}\n\n${markdown}`;
       const success = await importText(contentWithHeader, pageTitle, senderTabId);
       if (!success) throw new Error('Import failed. Make sure NotebookLM is open.');
       return true;

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -928,6 +928,9 @@ async function handleMessage(message: MessageType, senderTabId?: number): Promis
           target: { tabId: activeTab.id },
           func: () => ({ html: document.body.innerHTML, title: document.title }),
         });
+        if (!results?.[0]?.result) {
+          throw new Error('Could not capture this page type');
+        }
         extracted = results[0].result;
       } catch {
         throw new Error('Could not capture this page type');

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -200,7 +200,9 @@ export default defineBackground(() => {
         if (!results?.[0]?.result) throw new Error('Could not capture page content');
         const { html, title: tabTitle } = results[0].result;
         const { markdown, title } = await convertHtmlToMarkdown(html);
-        await importText(markdown, tabTitle || title);
+        const pageTitle = tabTitle || title;
+        const contentWithHeader = `# [${pageTitle}](${tab.url})\n\n${markdown}`;
+        await importText(contentWithHeader, pageTitle);
       } catch (error) {
         console.error('Context menu capture failed:', error);
       }
@@ -931,7 +933,8 @@ async function handleMessage(message: MessageType, senderTabId?: number): Promis
 
       const { markdown, title } = await convertHtmlToMarkdown(extracted.html);
       const pageTitle = extracted.title || title;
-      const success = await importText(markdown, pageTitle, senderTabId);
+      const contentWithHeader = `# [${pageTitle}](${tabUrl})\n\n${markdown}`;
+      const success = await importText(contentWithHeader, pageTitle, senderTabId);
       if (!success) throw new Error('Import failed. Make sure NotebookLM is open.');
       return true;
     }

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -916,6 +916,30 @@ async function _tabBasedExtract(urls: string[], extractOnly = false, targetTabId
 
 async function handleMessage(message: MessageType, senderTabId?: number): Promise<unknown> {
   switch (message.type) {
+    case 'CAPTURE_PAGE_CONTENT': {
+      const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (!activeTab?.id) throw new Error('No active tab found');
+      const tabUrl = activeTab.url || '';
+      if (!tabUrl.startsWith('http')) throw new Error('Cannot capture this page type');
+
+      let extracted: { html: string; title: string };
+      try {
+        const results = await chrome.scripting.executeScript({
+          target: { tabId: activeTab.id },
+          func: () => ({ html: document.body.innerHTML, title: document.title }),
+        });
+        extracted = results[0].result;
+      } catch {
+        throw new Error('Could not capture this page type');
+      }
+
+      const { markdown, title } = await convertHtmlToMarkdown(extracted.html);
+      const pageTitle = extracted.title || title;
+      const success = await importText(markdown, pageTitle, senderTabId);
+      if (!success) throw new Error('Import failed. Make sure NotebookLM is open.');
+      return true;
+    }
+
     case 'IMPORT_URL':
       return await importUrl(message.url, senderTabId);
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -202,7 +202,7 @@ export default defineBackground(() => {
         const { markdown, title } = await convertHtmlToMarkdown(html);
         const pageTitle = tabTitle || title;
         const headerTitle = title || tabTitle;
-        const contentWithHeader = `${headerTitle}\n${tab.url}\n\n${markdown}`;
+        const contentWithHeader = `[${headerTitle}](${tab.url})\n\n${markdown}`;
         await importText(contentWithHeader, pageTitle);
       } catch (error) {
         console.error('Context menu capture failed:', error);
@@ -935,8 +935,7 @@ async function handleMessage(message: MessageType, senderTabId?: number): Promis
       const { markdown, title } = await convertHtmlToMarkdown(extracted.html);
       const pageTitle = extracted.title || title;
       const headerTitle = title || extracted.title;
-      // Use plain text format — NotebookLM strips markdown # headings from pasted text
-      const contentWithHeader = `${headerTitle}\n${tabUrl}\n\n${markdown}`;
+      const contentWithHeader = `[${headerTitle}](${tabUrl})\n\n${markdown}`;
       const success = await importText(contentWithHeader, pageTitle, senderTabId);
       if (!success) throw new Error('Import failed. Make sure NotebookLM is open.');
       return true;

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -167,6 +167,7 @@ try {
 // Context menu IDs
 const MENU_ID_PAGE = 'import-page';
 const MENU_ID_LINK = 'import-link';
+const MENU_ID_CAPTURE = 'capture-page-content';
 
 export default defineBackground(() => {
   console.log('NotebookLM Jetpack background service started');
@@ -191,12 +192,38 @@ export default defineBackground(() => {
       title: '导入此链接到 NotebookLM',
       contexts: ['link'],
     });
+
+    // Menu item for capturing page content (for authenticated pages)
+    chrome.contextMenus.create({
+      id: MENU_ID_CAPTURE,
+      title: '导入此页面内容到 NotebookLM（适用于需登录页面）',
+      contexts: ['page'],
+    });
   });
 
   // Handle context menu clicks
   chrome.contextMenus.onClicked.addListener(async (info, tab) => {
-    let url: string | undefined;
+    if (info.menuItemId === MENU_ID_CAPTURE) {
+      if (!tab?.id || !tab.url?.startsWith('http')) {
+        console.warn('Context menu capture: invalid tab');
+        return;
+      }
+      try {
+        const results = await chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          func: () => ({ html: document.body.innerHTML, title: document.title }),
+        });
+        if (!results?.[0]?.result) throw new Error('Could not capture page content');
+        const { html, title: tabTitle } = results[0].result;
+        const { markdown, title } = await convertHtmlToMarkdown(html);
+        await importText(markdown, tabTitle || title);
+      } catch (error) {
+        console.error('Context menu capture failed:', error);
+      }
+      return;
+    }
 
+    let url: string | undefined;
     if (info.menuItemId === MENU_ID_PAGE) {
       url = tab?.url;
     } else if (info.menuItemId === MENU_ID_LINK) {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -932,8 +932,11 @@ async function handleMessage(message: MessageType, senderTabId?: number): Promis
       }
 
       const { markdown, title } = await convertHtmlToMarkdown(extracted.html);
+      // Use h1-derived title for the header link (clean), document.title for the source name
       const pageTitle = extracted.title || title;
-      const contentWithHeader = `# [${pageTitle}](${tabUrl})\n\n${markdown}`;
+      const headerTitle = title || extracted.title;
+      const contentWithHeader = `# [${headerTitle}](${tabUrl})\n\n${markdown}`;
+      console.log('[CAPTURE] header:', contentWithHeader.slice(0, 120));
       const success = await importText(contentWithHeader, pageTitle, senderTabId);
       if (!success) throw new Error('Import failed. Make sure NotebookLM is open.');
       return true;

--- a/entrypoints/notebooklm.content.ts
+++ b/entrypoints/notebooklm.content.ts
@@ -489,6 +489,7 @@ async function importTextToNotebookLM(text: string, title?: string): Promise<boo
     }
 
     // Step 4: Fill text content
+    console.log('[importText] text starts with:', JSON.stringify(text.slice(0, 150)));
     await fillInput(textArea, text);
 
     // Step 5: Click "插入" (Insert) button — wait longer for it to become enabled

--- a/entrypoints/notebooklm.content.ts
+++ b/entrypoints/notebooklm.content.ts
@@ -489,7 +489,6 @@ async function importTextToNotebookLM(text: string, title?: string): Promise<boo
     }
 
     // Step 4: Fill text content
-    console.log('[importText] text starts with:', JSON.stringify(text.slice(0, 150)));
     await fillInput(textArea, text);
 
     // Step 5: Click "插入" (Insert) button — wait longer for it to become enabled

--- a/entrypoints/notebooklm.content.ts
+++ b/entrypoints/notebooklm.content.ts
@@ -497,6 +497,14 @@ async function importTextToNotebookLM(text: string, title?: string): Promise<boo
     if (!insertButton) {
       throw new Error('Insert button not found');
     }
+    // Snapshot existing source titles before inserting, so we can identify the new source
+    // reliably regardless of list ordering (NotebookLM may reorder after a source is viewed).
+    const defaultNames = ['粘贴的文字', '复制的文字', 'Copied text', 'Pasted text', 'Pasted Text'];
+    const titlesBeforeInsert = new Set(
+      Array.from(document.querySelectorAll('.single-source-container'))
+        .map(el => (el.querySelector('.source-title') ?? el.querySelector('.source-title-column'))?.textContent?.trim() ?? '')
+    );
+
     // Wait for button to be enabled (disabled while processing input)
     for (let i = 0; i < 10; i++) {
       if (!(insertButton as HTMLButtonElement).disabled) break;
@@ -519,21 +527,34 @@ async function importTextToNotebookLM(text: string, title?: string): Promise<boo
       // Close any open source viewer panel so the source list is accessible for rename
       dismissAnyDialog();
       await delay(300);
-      const defaultNames = ['粘贴的文字', '复制的文字', 'Copied text', 'Pasted text', 'Pasted Text'];
       const allSources = document.querySelectorAll('.single-source-container');
-      if (allSources.length > 0) {
-        const lastSource = allSources[allSources.length - 1];
-        // Prefer .source-title (inner span) over .source-title-column (may contain extra nested text)
-        const sourceTitle = (lastSource.querySelector('.source-title') ?? lastSource.querySelector('.source-title-column'))?.textContent?.trim();
-        if (sourceTitle && defaultNames.includes(sourceTitle)) {
-          console.log(`[importText] Source still has default name "${sourceTitle}", renaming to "${title}"`);
-          try {
-            await renameSource(sourceTitle, title);
-          } catch (e) {
-            console.warn('[importText] Rename failed (non-fatal):', e);
-            // Ensure any leftover dialog is dismissed
-            dismissAnyDialog();
+      // Find the newly added source: prefer one with a default name that wasn't in the
+      // pre-insert snapshot. This handles list reordering after a source has been viewed.
+      let sourceTitle: string | undefined;
+      for (let i = allSources.length - 1; i >= 0; i--) {
+        const t = (allSources[i].querySelector('.source-title') ?? allSources[i].querySelector('.source-title-column'))?.textContent?.trim();
+        if (t && defaultNames.includes(t) && !titlesBeforeInsert.has(t)) {
+          sourceTitle = t;
+          break;
+        }
+      }
+      // Fallback: any source with a default name (covers case where previous rename also failed)
+      if (!sourceTitle) {
+        for (let i = allSources.length - 1; i >= 0; i--) {
+          const t = (allSources[i].querySelector('.source-title') ?? allSources[i].querySelector('.source-title-column'))?.textContent?.trim();
+          if (t && defaultNames.includes(t)) {
+            sourceTitle = t;
+            break;
           }
+        }
+      }
+      if (sourceTitle) {
+        console.log(`[importText] Source still has default name "${sourceTitle}", renaming to "${title}"`);
+        try {
+          await renameSource(sourceTitle, title);
+        } catch (e) {
+          console.warn('[importText] Rename failed (non-fatal):', e);
+          dismissAnyDialog();
         }
       }
     }

--- a/entrypoints/notebooklm.content.ts
+++ b/entrypoints/notebooklm.content.ts
@@ -513,12 +513,13 @@ async function importTextToNotebookLM(text: string, title?: string): Promise<boo
     // Smart rename: wait for NotebookLM to process, then check if it auto-renamed.
     // If the source still has a default name, rename it manually. (Fixes #38)
     if (title) {
-      await delay(3000);
+      await delay(5000);
       const defaultNames = ['粘贴的文字', '复制的文字', 'Copied text', 'Pasted text', 'Pasted Text'];
       const allSources = document.querySelectorAll('.single-source-container');
       if (allSources.length > 0) {
         const lastSource = allSources[allSources.length - 1];
-        const sourceTitle = lastSource.querySelector('.source-title')?.textContent?.trim();
+        // Prefer .source-title (inner span) over .source-title-column (may contain extra nested text)
+        const sourceTitle = (lastSource.querySelector('.source-title') ?? lastSource.querySelector('.source-title-column'))?.textContent?.trim();
         if (sourceTitle && defaultNames.includes(sourceTitle)) {
           console.log(`[importText] Source still has default name "${sourceTitle}", renaming to "${title}"`);
           try {
@@ -858,8 +859,9 @@ async function renameSource(oldName: string, newName: string): Promise<void> {
   // Search from last to first (most recently added source is at the bottom)
   for (let i = allItems.length - 1; i >= 0; i--) {
     const item = allItems[i];
-    const titleEl = item.querySelector('.source-title-column');
-    if (titleEl?.textContent?.trim() === oldName) {
+    // Prefer .source-title (inner span) — .source-title-column may include extra nested text
+    const titleText = (item.querySelector('.source-title') ?? item.querySelector('.source-title-column'))?.textContent?.trim();
+    if (titleText === oldName) {
       targetMoreBtn = item.querySelector('.source-item-more-button') as HTMLElement;
       if (!targetMoreBtn) {
         // Fallback: find button with aria-label="更多"

--- a/entrypoints/notebooklm.content.ts
+++ b/entrypoints/notebooklm.content.ts
@@ -513,7 +513,7 @@ async function importTextToNotebookLM(text: string, title?: string): Promise<boo
     // Smart rename: wait for NotebookLM to process, then check if it auto-renamed.
     // If the source still has a default name, rename it manually. (Fixes #38)
     if (title) {
-      await delay(5000);
+      await delay(3000);
       const defaultNames = ['粘贴的文字', '复制的文字', 'Copied text', 'Pasted text', 'Pasted Text'];
       const allSources = document.querySelectorAll('.single-source-container');
       if (allSources.length > 0) {

--- a/entrypoints/notebooklm.content.ts
+++ b/entrypoints/notebooklm.content.ts
@@ -497,13 +497,10 @@ async function importTextToNotebookLM(text: string, title?: string): Promise<boo
     if (!insertButton) {
       throw new Error('Insert button not found');
     }
-    // Snapshot existing source titles before inserting, so we can identify the new source
-    // reliably regardless of list ordering (NotebookLM may reorder after a source is viewed).
     const defaultNames = ['粘贴的文字', '复制的文字', 'Copied text', 'Pasted text', 'Pasted Text'];
-    const titlesBeforeInsert = new Set(
-      Array.from(document.querySelectorAll('.single-source-container'))
-        .map(el => (el.querySelector('.source-title') ?? el.querySelector('.source-title-column'))?.textContent?.trim() ?? '')
-    );
+
+    // Snapshot source count before inserting so we can detect when the new source appears.
+    const countBefore = document.querySelectorAll('.single-source-container').length;
 
     // Wait for button to be enabled (disabled while processing input)
     for (let i = 0; i < 10; i++) {
@@ -512,40 +509,32 @@ async function importTextToNotebookLM(text: string, title?: string): Promise<boo
     }
     insertButton.click();
 
-    // Wait for the Add Source dialog to close / import to complete.
-    // Check specifically for the Add Source dialog (not a source viewer the user may have open).
+    // Wait for the Add Source dialog to close.
     for (let i = 0; i < 10; i++) {
       await delay(1000);
       const dialog = getMainDialog();
       if (!dialog || !isAddSourceDialog(dialog)) break;
     }
 
-    // Smart rename: wait for NotebookLM to process, then check if it auto-renamed.
-    // If the source still has a default name, rename it manually. (Fixes #38)
+    // Smart rename: wait for the new source to actually appear in the list,
+    // then rename if it still has a default name. (Fixes #38)
     if (title) {
-      await delay(3000);
-      // Close any open source viewer panel so the source list is accessible for rename
-      dismissAnyDialog();
-      await delay(300);
+      // Wait for source count to increase (reliable signal that import completed)
+      for (let i = 0; i < 10; i++) {
+        await delay(1000);
+        if (document.querySelectorAll('.single-source-container').length > countBefore) break;
+      }
+      // Extra wait for NotebookLM to finish processing (auto-rename may happen)
+      await delay(2000);
+
       const allSources = document.querySelectorAll('.single-source-container');
-      // Find the newly added source: prefer one with a default name that wasn't in the
-      // pre-insert snapshot. This handles list reordering after a source has been viewed.
+      // Scan all sources for one with a default name (new source may be at any position)
       let sourceTitle: string | undefined;
       for (let i = allSources.length - 1; i >= 0; i--) {
         const t = (allSources[i].querySelector('.source-title') ?? allSources[i].querySelector('.source-title-column'))?.textContent?.trim();
-        if (t && defaultNames.includes(t) && !titlesBeforeInsert.has(t)) {
+        if (t && defaultNames.includes(t)) {
           sourceTitle = t;
           break;
-        }
-      }
-      // Fallback: any source with a default name (covers case where previous rename also failed)
-      if (!sourceTitle) {
-        for (let i = allSources.length - 1; i >= 0; i--) {
-          const t = (allSources[i].querySelector('.source-title') ?? allSources[i].querySelector('.source-title-column'))?.textContent?.trim();
-          if (t && defaultNames.includes(t)) {
-            sourceTitle = t;
-            break;
-          }
         }
       }
       if (sourceTitle) {

--- a/entrypoints/notebooklm.content.ts
+++ b/entrypoints/notebooklm.content.ts
@@ -504,16 +504,21 @@ async function importTextToNotebookLM(text: string, title?: string): Promise<boo
     }
     insertButton.click();
 
-    // Wait for dialog to close / import to complete
+    // Wait for the Add Source dialog to close / import to complete.
+    // Check specifically for the Add Source dialog (not a source viewer the user may have open).
     for (let i = 0; i < 10; i++) {
       await delay(1000);
-      if (!getMainDialog()) break;
+      const dialog = getMainDialog();
+      if (!dialog || !isAddSourceDialog(dialog)) break;
     }
 
     // Smart rename: wait for NotebookLM to process, then check if it auto-renamed.
     // If the source still has a default name, rename it manually. (Fixes #38)
     if (title) {
       await delay(3000);
+      // Close any open source viewer panel so the source list is accessible for rename
+      dismissAnyDialog();
+      await delay(300);
       const defaultNames = ['粘贴的文字', '复制的文字', 'Copied text', 'Pasted text', 'Pasted Text'];
       const allSources = document.querySelectorAll('.single-source-container');
       if (allSources.length > 0) {

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -3,6 +3,7 @@
  * Service workers can't use DOMParser/Turndown reliably, so we delegate here.
  */
 import TurndownService from 'turndown';
+import { tables } from 'turndown-plugin-gfm';
 
 function createTurndownService(): TurndownService {
   const td = new TurndownService({
@@ -67,6 +68,9 @@ function createTurndownService(): TurndownService {
     filter: 'figcaption',
     replacement: (content) => content.trim() ? `\n*${content.trim()}*\n` : '',
   });
+
+  // GFM table support (converts <table> to Markdown pipe tables)
+  td.use(tables);
 
   return td;
 }

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -130,6 +130,15 @@ const REMOVE_SELECTORS = [
   '.social-share',
   '[data-testid="navbar"]',
   '.header-anchor-widget',
+  // Confluence: sections outside the article body
+  '#labels-section',
+  '#comments-section',
+  '#space-tools-web-items',
+  '.page-metadata',
+  // Generic: like/reaction widgets and interactive toolbars
+  '[role="toolbar"]',
+  '.like-button-container',
+  '.likes-section',
 ].join(',');
 
 function htmlToMarkdown(html: string): { markdown: string; title: string } {

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -85,9 +85,16 @@ const CONTENT_SELECTORS = [
   '.available-content .body.markup',
   '.available-content',
   '.body.markup',
-  // General
+  // General — specific content containers before broad layout landmarks
   '.markdown-body',
   'article [itemprop="articleBody"]',
+  '#main-content',          // Confluence, WordPress, many CMSes
+  '.wiki-content',          // Confluence wiki body
+  '.entry-content',         // WordPress posts
+  '.post-content',          // WordPress/Ghost
+  '.page-content',          // Generic CMS
+  '.article-content',       // Generic
+  '.article-body',          // Generic
   'article',
   'main',
   '[role="main"]',

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -132,6 +132,12 @@ function htmlToMarkdown(html: string): { markdown: string; title: string } {
   }
   if (!el) el = doc.body;
 
+  // Fallback: if smart extraction yields < 200 chars, use full body
+  const smartText = el.textContent?.trim() || '';
+  if (smartText.length < 200 && el !== doc.body) {
+    el = doc.body;
+  }
+
   // Remove non-content elements
   el.querySelectorAll(REMOVE_SELECTORS).forEach(e => e.remove());
 

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -145,6 +145,16 @@ function htmlToMarkdown(html: string): { markdown: string; title: string } {
   // Remove non-content elements
   el.querySelectorAll(REMOVE_SELECTORS).forEach(e => e.remove());
 
+  // Flatten block elements inside table cells so GFM table rows stay single-line.
+  // Confluence (and other editors) wrap cell content in <p> tags, which Turndown
+  // treats as block elements and adds newlines around — breaking pipe table format.
+  el.querySelectorAll('td, th').forEach(cell => {
+    cell.querySelectorAll('p, div, span').forEach(inner => {
+      const text = inner.textContent || '';
+      inner.replaceWith(doc.createTextNode(text.trim()));
+    });
+  });
+
   const title = doc.querySelector('h1')?.textContent?.trim() || doc.title || '';
 
   // Convert to markdown

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -139,6 +139,8 @@ const REMOVE_SELECTORS = [
   '[role="toolbar"]',
   '.like-button-container',
   '.likes-section',
+  // Stiltsoft Table Filter & Charts plugin (Confluence)
+  '[id^="tfac-"]',
 ].join(',');
 
 function htmlToMarkdown(html: string): { markdown: string; title: string } {

--- a/lib/env.d.ts
+++ b/lib/env.d.ts
@@ -1,3 +1,11 @@
 declare const __GIT_HASH__: string;
 declare const __BUILD_TIME__: string;
 declare const __VERSION__: string;
+
+declare module 'turndown-plugin-gfm' {
+  import TurndownService from 'turndown';
+  export function tables(service: TurndownService): void;
+  export function strikethrough(service: TurndownService): void;
+  export function taskListItems(service: TurndownService): void;
+  export const gfm: (service: TurndownService) => void;
+}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -161,6 +161,11 @@ const zh = {
   'single.webArticles': '普通网页文章',
   'single.substackWechat': 'Substack / 微信公众号（智能提取正文）',
   'single.pdfLinks': 'PDF 文件链接',
+  'single.captureContent': '导入页面内容',
+  'single.capturingBtn': '捕获中',
+  'single.captureFailedHint': '页面内容捕获失败，请确保页面已完全加载',
+  'single.captureNotSupported': '无法捕获此类页面',
+  'single.captureAuthHint': '适用于需要登录的内部页面（Confluence、企业 Wiki 等）',
 
   // ── ClaudeImport ──
   'claude.extractFailed': '提取对话失败',
@@ -441,6 +446,11 @@ const en: Record<keyof typeof zh, string> = {
   'single.webArticles': 'Web articles',
   'single.substackWechat': 'Substack / WeChat articles (smart extraction)',
   'single.pdfLinks': 'PDF file links',
+  'single.captureContent': 'Import Page Content',
+  'single.capturingBtn': 'Capturing',
+  'single.captureFailedHint': 'Failed to capture page content. Make sure the page is fully loaded.',
+  'single.captureNotSupported': 'Cannot capture this page type',
+  'single.captureAuthHint': 'Use for pages requiring login (Confluence, internal wikis, etc.)',
 
   // ── ClaudeImport ──
   'claude.extractFailed': 'Failed to extract conversation',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -80,6 +80,7 @@ export interface YouTubeResult {
 export type MessageType =
   | { type: 'IMPORT_URL'; url: string }
   | { type: 'IMPORT_BATCH'; urls: string[] }
+  | { type: 'CAPTURE_PAGE_CONTENT' }
   | { type: 'PARSE_RSS'; rssUrl: string }
   | { type: 'GET_CURRENT_TAB' }
   | { type: 'GET_ALL_TABS' }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,44 @@
 {
   "name": "notebooklm-jetpack",
-  "version": "1.5.4",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notebooklm-jetpack",
-      "version": "1.5.4",
+      "version": "1.7.2",
       "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-tabs": "^1.1.13",
         "clsx": "^2.1.1",
+        "html-to-image": "^1.11.13",
+        "jspdf": "^4.2.0",
         "lucide-react": "^0.454.0",
+        "marked": "^17.0.3",
+        "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "tailwind-merge": "^2.2.0"
+        "tailwind-merge": "^2.2.0",
+        "turndown": "^7.2.2",
+        "turndown-plugin-gfm": "^1.0.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/chrome": "^0.0.258",
         "@types/react": "^18.2.64",
         "@types/react-dom": "^18.2.21",
+        "@types/turndown": "^5.0.6",
+        "@vitest/coverage-v8": "^4.0.18",
         "@wxt-dev/module-react": "^1.0.0",
         "autoprefixer": "^10.4.17",
         "eslint": "^8.56.0",
+        "jsdom": "^28.1.0",
+        "pdfkit": "^0.17.2",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.3.3",
+        "vitest": "^4.0.18",
         "wxt": "^0.19.16"
       },
       "engines": {
@@ -42,6 +55,20 @@
         "defu": "^6.1.4",
         "many-keys-map": "^2.0.1"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@aklinker1/rollup-plugin-visualizer": {
       "version": "5.12.0",
@@ -139,6 +166,64 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
+      "integrity": "sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -379,7 +464,7 @@
       "version": "7.28.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
       "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -431,6 +516,171 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@devicefarmer/adbkit": {
@@ -1008,6 +1258,24 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1118,6 +1386,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1890,6 +2164,106 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.20.tgz",
+      "integrity": "sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1935,6 +2309,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/chrome": {
       "version": "0.0.258",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.258.tgz",
@@ -1945,6 +2330,13 @@
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1995,12 +2387,25 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
@@ -2024,6 +2429,20 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/webextension-polyfill": {
       "version": "0.12.4",
@@ -2058,6 +2477,162 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@webext-core/fake-browser": {
@@ -2161,6 +2736,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2299,6 +2884,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-differ": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
@@ -2324,6 +2919,35 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -2407,6 +3031,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -2415,6 +3070,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2515,6 +3180,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -2777,6 +3452,36 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3041,6 +3746,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3171,6 +3886,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -3193,6 +3920,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -3210,6 +3954,21 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -3222,6 +3981,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -3243,12 +4009,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -3274,6 +4080,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -3359,6 +4172,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -3385,6 +4205,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3428,6 +4255,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -3838,6 +4675,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -3896,6 +4743,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fast-redact": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
@@ -3915,6 +4779,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -4010,6 +4880,24 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/form-data-encoder": {
       "version": "4.1.0",
@@ -4438,12 +5326,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -4476,6 +5397,34 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -4543,6 +5492,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4571,6 +5530,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-absolute": {
       "version": "0.1.7",
@@ -4889,6 +5854,52 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports/node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -4899,6 +5910,14 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4917,6 +5936,48 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4987,6 +6048,32 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/jszip": {
@@ -5097,6 +6184,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -5359,6 +6467,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5382,6 +6500,35 @@
         "source-map-js": "^1.2.0"
       }
     },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -5399,12 +6546,31 @@
         "url": "https://github.com/sponsors/fregante"
       }
     },
+    "node_modules/marked": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5461,6 +6627,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5859,6 +7035,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -6153,6 +7340,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6197,12 +7410,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pdfkit": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.2.tgz",
+      "integrity": "sha512-UnwF5fXy08f0dnp4jchFYAROKMNTaPqb/xgR8GtCzIcqoTnbOqtp3bwKvO4688oHI6vzEEs8Q6vqqEnC5IUELw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6295,6 +7529,12 @@
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==",
+      "dev": true
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -6470,6 +7710,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6587,6 +7855,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -6631,6 +7908,16 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -6703,6 +7990,13 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -6762,6 +8056,27 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/registry-auth-token": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
@@ -6795,6 +8110,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6865,6 +8190,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6882,6 +8214,16 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -6906,6 +8248,7 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7009,6 +8352,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -7097,6 +8453,13 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -7234,6 +8597,30 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
@@ -7343,6 +8730,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7442,6 +8842,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
@@ -7516,6 +8933,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7560,6 +8987,20 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7622,6 +9063,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -7645,6 +9116,32 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -7658,6 +9155,21 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7720,10 +9232,49 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7918,6 +9469,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -8059,6 +9620,122 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -8126,12 +9803,47 @@
       "dev": true,
       "license": "MPL-2.0"
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/when": {
       "version": "3.7.7",
@@ -8161,6 +9873,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -9021,6 +10750,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -9044,6 +10783,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwind-merge": "^2.2.0",
-    "turndown": "^7.2.2"
+    "turndown": "^7.2.2",
+    "turndown-plugin-gfm": "^1.0.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/tests/offscreen-page-capture.test.ts
+++ b/tests/offscreen-page-capture.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 // We test the fallback logic by extracting htmlToMarkdown into a testable form.
 // Since the offscreen module runs in a Chrome context, we reproduce the pure logic here.

--- a/tests/offscreen-page-capture.test.ts
+++ b/tests/offscreen-page-capture.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// We test the fallback logic by extracting htmlToMarkdown into a testable form.
+// Since the offscreen module runs in a Chrome context, we reproduce the pure logic here.
+
+import TurndownService from 'turndown';
+
+const CONTENT_SELECTORS = [
+  '.devsite-article-body',
+  '.doc-content', '.document-content',
+  '.available-content .body.markup', '.available-content', '.body.markup',
+  '.markdown-body',
+  'article [itemprop="articleBody"]',
+  'article', 'main', '[role="main"]', '#content', '.prose', '.content',
+];
+
+const REMOVE_SELECTORS = [
+  'script', 'style', 'nav', 'footer', 'header',
+  '.sidebar', '.toc', '.breadcrumb',
+].join(',');
+
+function htmlToMarkdownWithFallback(html: string): { markdown: string; title: string } {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+
+  let el: Element | null = null;
+  for (const s of CONTENT_SELECTORS) {
+    el = doc.querySelector(s);
+    if (el) break;
+  }
+  if (!el) el = doc.body;
+
+  // Fallback: if smart extraction yields < 200 chars, use full body
+  const smartText = el.textContent?.trim() || '';
+  if (smartText.length < 200 && el !== doc.body) {
+    el = doc.body;
+  }
+
+  el.querySelectorAll(REMOVE_SELECTORS).forEach(e => e.remove());
+
+  const title = doc.querySelector('h1')?.textContent?.trim() || doc.title || '';
+  const td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced', bulletListMarker: '-' });
+  const markdown = td.turndown(el.innerHTML).replace(/\n{3,}/g, '\n\n').trim();
+
+  return { markdown, title };
+}
+
+describe('htmlToMarkdown fallback logic', () => {
+  it('uses smart selector when content is >= 200 chars', () => {
+    const longText = 'a'.repeat(300);
+    const html = `<html><body>
+      <nav>Navigation</nav>
+      <article>${longText}</article>
+    </body></html>`;
+    const { markdown } = htmlToMarkdownWithFallback(html);
+    // Should use <article> content only, nav stripped
+    expect(markdown).toContain('a'.repeat(200));
+    expect(markdown).not.toContain('Navigation');
+  });
+
+  it('falls back to full body when smart selector yields < 200 chars', () => {
+    const html = `<html><body>
+      <article>Short.</article>
+      <div class="sidebar-content">This is extra content outside article that should appear in fallback mode with plenty of text to confirm fallback works correctly here and now.</div>
+    </body></html>`;
+    const { markdown } = htmlToMarkdownWithFallback(html);
+    // Should include the sidebar div since fallback uses body
+    expect(markdown).toContain('extra content outside article');
+  });
+
+  it('uses body directly when no selector matches', () => {
+    const html = `<html><title>My Page</title><body><p>Hello world content that is quite short</p></body></html>`;
+    const { markdown } = htmlToMarkdownWithFallback(html);
+    expect(markdown).toContain('Hello world');
+  });
+
+  it('extracts title from h1', () => {
+    const html = `<html><body><article><h1>My Title</h1>${'content '.repeat(50)}</article></body></html>`;
+    const { title } = htmlToMarkdownWithFallback(html);
+    expect(title).toBe('My Title');
+  });
+});

--- a/tests/services/page-capture.test.ts
+++ b/tests/services/page-capture.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We test the handler logic by extracting it into a testable helper.
+// The actual case in background.ts calls the same pattern.
+
+async function capturePageContent(
+  tabId: number,
+  tabUrl: string,
+  executeScript: (opts: { target: { tabId: number }; func: () => { html: string; title: string } }) => Promise<Array<{ result: { html: string; title: string } }>>,
+  convertHtmlToMarkdown: (html: string) => Promise<{ markdown: string; title: string }>,
+  importText: (text: string, title: string, senderTabId?: number) => Promise<boolean>,
+  senderTabId?: number
+): Promise<boolean> {
+  if (!tabUrl.startsWith('http')) {
+    throw new Error('Cannot capture this page type');
+  }
+  let extracted: { html: string; title: string };
+  try {
+    const result = await executeScript({ target: { tabId }, func: () => ({ html: document.body.innerHTML, title: document.title }) });
+    extracted = result[0].result;
+  } catch {
+    throw new Error('Could not capture this page type');
+  }
+  const { markdown, title } = await convertHtmlToMarkdown(extracted.html);
+  const pageTitle = extracted.title || title;
+  const success = await importText(markdown, pageTitle, senderTabId);
+  if (!success) throw new Error('Import failed');
+  return true;
+}
+
+describe('capturePageContent', () => {
+  const mockExecuteScript = vi.fn();
+  const mockConvert = vi.fn();
+  const mockImport = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('extracts HTML from tab, converts to markdown, and imports', async () => {
+    mockExecuteScript.mockResolvedValue([{ result: { html: '<p>Hello</p>', title: 'My Page' } }]);
+    mockConvert.mockResolvedValue({ markdown: '# Hello', title: 'My Page' });
+    mockImport.mockResolvedValue(true);
+
+    const result = await capturePageContent(42, 'https://example.com', mockExecuteScript, mockConvert, mockImport, 1);
+
+    expect(result).toBe(true);
+    expect(mockExecuteScript).toHaveBeenCalledWith(expect.objectContaining({ target: { tabId: 42 } }));
+    expect(mockConvert).toHaveBeenCalledWith('<p>Hello</p>');
+    expect(mockImport).toHaveBeenCalledWith('# Hello', 'My Page', 1);
+  });
+
+  it('throws for non-http URLs', async () => {
+    await expect(
+      capturePageContent(1, 'chrome://extensions', mockExecuteScript, mockConvert, mockImport)
+    ).rejects.toThrow('Cannot capture this page type');
+    expect(mockExecuteScript).not.toHaveBeenCalled();
+  });
+
+  it('throws when executeScript fails (restricted tab)', async () => {
+    mockExecuteScript.mockRejectedValue(new Error('Cannot access a chrome extension URL'));
+    await expect(
+      capturePageContent(1, 'https://example.com', mockExecuteScript, mockConvert, mockImport)
+    ).rejects.toThrow('Could not capture this page type');
+  });
+
+  it('throws when importText returns false', async () => {
+    mockExecuteScript.mockResolvedValue([{ result: { html: '<p>x</p>', title: 'T' } }]);
+    mockConvert.mockResolvedValue({ markdown: 'x', title: 'T' });
+    mockImport.mockResolvedValue(false);
+
+    await expect(
+      capturePageContent(1, 'https://example.com', mockExecuteScript, mockConvert, mockImport)
+    ).rejects.toThrow('Import failed');
+  });
+
+  it('uses tab title when markdown title is empty', async () => {
+    mockExecuteScript.mockResolvedValue([{ result: { html: '<p>content</p>', title: 'Tab Title' } }]);
+    mockConvert.mockResolvedValue({ markdown: 'content', title: '' });
+    mockImport.mockResolvedValue(true);
+
+    await capturePageContent(1, 'https://example.com', mockExecuteScript, mockConvert, mockImport);
+    expect(mockImport).toHaveBeenCalledWith('content', 'Tab Title', undefined);
+  });
+});

--- a/tests/services/page-capture.test.ts
+++ b/tests/services/page-capture.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // We test the handler logic by extracting it into a testable helper.
-// The actual case in background.ts calls the same pattern.
+// NOTE: This re-implements the handler logic locally — it does not import from background.ts.
+// If the handler in background.ts is changed, update this helper to match.
 
 async function capturePageContent(
   tabId: number,
@@ -16,8 +17,11 @@ async function capturePageContent(
   }
   let extracted: { html: string; title: string };
   try {
-    const result = await executeScript({ target: { tabId }, func: () => ({ html: document.body.innerHTML, title: document.title }) });
-    extracted = result[0].result;
+    const results = await executeScript({ target: { tabId }, func: () => ({ html: document.body.innerHTML, title: document.title }) });
+    if (!results?.[0]?.result) {
+      throw new Error('Could not capture this page type');
+    }
+    extracted = results[0].result;
   } catch {
     throw new Error('Could not capture this page type');
   }
@@ -59,6 +63,20 @@ describe('capturePageContent', () => {
 
   it('throws when executeScript fails (restricted tab)', async () => {
     mockExecuteScript.mockRejectedValue(new Error('Cannot access a chrome extension URL'));
+    await expect(
+      capturePageContent(1, 'https://example.com', mockExecuteScript, mockConvert, mockImport)
+    ).rejects.toThrow('Could not capture this page type');
+  });
+
+  it('throws when executeScript returns empty results', async () => {
+    mockExecuteScript.mockResolvedValue([]);
+    await expect(
+      capturePageContent(1, 'https://example.com', mockExecuteScript, mockConvert, mockImport)
+    ).rejects.toThrow('Could not capture this page type');
+  });
+
+  it('throws when executeScript result is undefined', async () => {
+    mockExecuteScript.mockResolvedValue([{ result: undefined }]);
     await expect(
       capturePageContent(1, 'https://example.com', mockExecuteScript, mockConvert, mockImport)
     ).rejects.toThrow('Could not capture this page type');


### PR DESCRIPTION
Update with Claude assitant for the following changes:

1. Change the import page function to convert page content to mark down format and paste the text as the new source
2. Add page title with hyperlink to the top of the page
3. Handle table format
4. Rename the new paste text with the original page title
5. Handle confluence page to exclude header and footer and only keep the main content.