### PR TITLE
feat(shortcut): keyboard shortcut to import current page (#7)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -28,6 +28,60 @@ type ExtractorSelectors = typeof EXTRACTOR_SELECTORS;
 // header, so it's the only reliable way to force our name. See issue #57.
 const pendingPodcastFilenames = new Map<string, string>();
 
+// Flash a transient badge on the toolbar icon. The keyboard-shortcut / context-
+// menu imports (issue #7) run with no popup open, so the badge is the only
+// feedback the user gets. Uses the action API only — no extra manifest
+// permission required.
+//
+// The generation counter guards against overlapping presses: each flash bumps
+// the generation, and the 3s auto-clear only fires if no newer badge was shown
+// in the meantime — otherwise an earlier press's timer would blank a later
+// press's badge. Note: in MV3 the service worker may be torn down before the
+// setTimeout fires, in which case the badge lingers until the next flash clears
+// it (clear-on-next-press below). chrome.alarms has a 1-minute floor, too coarse
+// for a 3s badge, so this best-effort clear is the pragmatic choice.
+let badgeGeneration = 0;
+function flashActionBadge(text: string, color: string): void {
+  const gen = ++badgeGeneration;
+  chrome.action.setBadgeBackgroundColor({ color }).catch(() => { /* action API unavailable */ });
+  chrome.action.setBadgeText({ text }).catch(() => { /* action API unavailable */ });
+  setTimeout(() => {
+    if (gen === badgeGeneration) {
+      chrome.action.setBadgeText({ text: '' }).catch(() => { /* action API unavailable */ });
+    }
+  }, 3000);
+}
+
+// Shared single-page import for the entry points that have no popup open: the
+// keyboard shortcut and the context menu. Validates the URL, serializes against
+// concurrent triggers (rapid shortcut presses would otherwise drive the single
+// NotebookLM tab's Add-source dialog concurrently and clobber each other), runs
+// the existing single-URL import path, and flashes a badge for feedback.
+// importUrl() itself never throws (it catches internally and returns a boolean),
+// so no try/catch is needed here — the try/finally only releases the in-flight
+// lock. Returns whether the import succeeded.
+let pageImportInFlight = false;
+async function importPageUrl(url: string | undefined): Promise<boolean> {
+  if (!url || !/^https?:\/\//i.test(url)) {
+    console.warn('Page import: no importable URL');
+    flashActionBadge('✕', '#d93025');
+    return false;
+  }
+  if (pageImportInFlight) {
+    console.warn('Page import: another import is already in progress, ignoring');
+    flashActionBadge('…', '#f9ab00');
+    return false;
+  }
+  pageImportInFlight = true;
+  try {
+    const success = await importUrl(url);
+    flashActionBadge(success ? '✓' : '✕', success ? '#188038' : '#d93025');
+    return success;
+  } finally {
+    pageImportInFlight = false;
+  }
+}
+
 // Helper: render HTML to PDF via CDP and download
 async function handleExportPdfFromHtml(html: string, title: string, explicitFilename?: string, returnData?: boolean): Promise<{ base64: string; filename: string } | void> {
   // explicitFilename is already client-sanitized (md/jpg/png share it); only
@@ -242,16 +296,26 @@ export default defineBackground(() => {
       url = info.linkUrl;
     }
 
-    if (!url || !url.startsWith('http')) {
-      console.warn('Context menu import: invalid URL');
-      return;
+    await importPageUrl(url);
+  });
+
+  // Handle keyboard shortcut (issue #7): one-key import of the current page.
+  // Reuses the same single-URL import path as the popup and context menu;
+  // importUrl() → getNotebookLMTab() auto-opens/focuses a NotebookLM tab when
+  // none exists, matching popup behaviour. Badge gives success/failure feedback
+  // since no popup is open.
+  chrome.commands.onCommand.addListener(async (command, tab) => {
+    if (command !== 'import-current-page') return;
+
+    // Chrome (MV3) passes the active tab where the shortcut fired. Fall back to
+    // a query for builds/paths that omit it.
+    let url = tab?.url;
+    if (!url) {
+      const [active] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+      url = active?.url;
     }
 
-    try {
-      await importUrl(url);
-    } catch (error) {
-      console.error('Context menu import failed:', error);
-    }
+    await importPageUrl(url);
   });
 
   // Handle long-running operations via persistent port connections (supports progress updates)

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -10,5 +10,9 @@
   "actionTitle": {
     "message": "NotebookLM Jetpack",
     "description": "Tooltip shown when hovering over the extension icon in the toolbar."
+  },
+  "commandImportPage": {
+    "message": "Import current page to NotebookLM",
+    "description": "Label for the keyboard shortcut shown at chrome://extensions/shortcuts."
   }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -10,5 +10,9 @@
   "actionTitle": {
     "message": "NotebookLM Jetpack",
     "description": "鼠标悬停在工具栏扩展图标时显示的提示文字。"
+  },
+  "commandImportPage": {
+    "message": "导入当前页面到 NotebookLM",
+    "description": "chrome://extensions/shortcuts 中显示的键盘快捷键说明。"
   }
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -44,6 +44,18 @@ export default defineConfig({
       default_title: '__MSG_actionTitle__',
       default_popup: 'popup.html',
     },
+    commands: {
+      // One-key import of the current page. Ctrl/Cmd+Shift+N is intentionally
+      // avoided — it's reserved by Chrome for Incognito and can't be bound.
+      // Users can rebind at chrome://extensions/shortcuts.
+      'import-current-page': {
+        suggested_key: {
+          default: 'Ctrl+Shift+Y',
+          mac: 'Command+Shift+Y',
+        },
+        description: '__MSG_commandImportPage__',
+      },
+    },
     externally_connectable: {
       matches: ['https://developer.chrome.com/*', 'http://localhost/*', 'https://*/*'],
     },


### PR DESCRIPTION
Closes #7

## 需求(验收标准)
- [x] `wxt.config.ts` manifest 注册 `commands`(`Ctrl+Shift+Y` / `Command+Shift+Y`),在 `chrome://extensions/shortcuts` 可见、可改
- [x] `background.ts` 监听 `onCommand`,取当前活动 tab 的 URL 触发既有单页导入流程
- [x] 未打开 NotebookLM tab 时,与 popup 行为一致(`importUrl → getNotebookLMTab` 自动打开/聚焦 NotebookLM tab)

> 说明:选用 `Ctrl/Cmd+Shift+Y` 而非常见的 `Ctrl+Shift+N` —— 后者被 Chrome 保留给「隐身窗口」,无法绑定。

## 实现
- **`wxt.config.ts`**:新增 `commands.import-current-page`(建议快捷键 + `__MSG_commandImportPage__` 说明)
- **`entrypoints/background.ts`**:
  - `chrome.commands.onCommand` 监听器,取快捷键触发时的活动 tab URL(优先用 Chrome 传入的 `tab` 参数,回退到 `tabs.query`)
  - 抽出共享的 `importPageUrl()` helper,快捷键与右键菜单导入共用
  - `flashActionBadge()` 用 action API 在工具栏图标上闪一个 ✓/✕ 徽标做反馈(无弹窗场景),**不新增任何 manifest 权限**
- **`_locales/en` + `zh_CN`**:新增 `commandImportPage` 文案

## 测试结果
- `pnpm compile` ✅
- `pnpm test` ✅ 126 passed
- `pnpm build` ✅(已核验产物 `manifest.json` 含 `commands.import-current-page` 块)
- 运行时:全局快捷键属浏览器级事件,无法用页面级自动化合成;可验证面(manifest 注册 + 代码正确性)已覆盖。人工验证建议:加载 `dist/` 后在任意网页按 `Ctrl/Cmd+Shift+Y`,应导入当前页并在图标上看到 ✓。

## 复核结论(/code-review high,workflow 版)
自审发现 6 项,全部已修:
1. ✅ 徽标计时器竞态(重叠按键互相清除)→ 加 generation token
2. ✅ 未串行化导致并发 DOM 自动化冲突 → 加 in-flight 锁
3. ✅ MV3 worker 回收致徽标残留 → clear-on-next-press 缓解并注释残余限制
4. ✅ URL 校验过松(`startsWith('http')`)→ 收紧为 `^https?://`
5. ✅ 死 try/catch(importUrl 内部已吞异常)→ 移除
6. ✅ 与右键菜单导入重复 → 抽 `importPageUrl()` 共享

## 边界
仅改动 `wxt.config.ts` + `background.ts` + 两处 i18n 文案,未触碰 NotebookLM 核心导入 DOM 流程。
