### PR TITLE
feat(x): preserve X.com article images in PDF export (#34)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -112,6 +112,18 @@ async function handleExportPdfFromHtml(html: string, title: string, explicitFile
   // Wait for render
   await new Promise(r => setTimeout(r, 2000));
 
+  // Wait for remote images (e.g. X-article pbs.twimg.com images, issue #34) to
+  // finish loading before printing, capped so a broken image can't hang export.
+  // No-op when the page has no images (resolves immediately).
+  await cdpAwait(tabId, `new Promise((res) => {
+    const imgs = Array.from(document.images || []).filter(i => !i.complete);
+    if (!imgs.length) return res(true);
+    let left = imgs.length;
+    const done = () => { if (--left <= 0) res(true); };
+    imgs.forEach(i => { i.addEventListener('load', done, { once: true }); i.addEventListener('error', done, { once: true }); });
+    setTimeout(() => res(true), 5000);
+  })`);
+
   // Print to PDF
   console.log('[EXPORT_PDF] Printing to PDF...');
   const result = await new Promise<{ data: string }>((resolve, reject) => {
@@ -156,6 +168,19 @@ function cdpEvaluate(tabId: number, expression: string): Promise<void> {
     chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', { expression }, () => {
       if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
       else resolve();
+    });
+  });
+}
+
+// Evaluate an expression that returns a Promise and wait for it to settle
+// (awaitPromise). Best-effort: resolves even on error so a stuck page never
+// blocks the print. Used to wait for remote images to finish loading before
+// Page.printToPDF (issue #34 — X-article images load over the network).
+function cdpAwait(tabId: number, expression: string): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', { expression, awaitPromise: true }, () => {
+      void chrome.runtime.lastError; // swallow; print proceeds regardless
+      resolve();
     });
   });
 }
@@ -773,7 +798,8 @@ async function _tabBasedExtractWithProgress(
       const extractResult = await chrome.scripting.executeScript({
         target: { tabId: tab.id },
         func: _tabExtractorFunction,
-        args: [EXTRACTOR_SELECTORS],
+        // includeImages = extractOnly: images only on the export path (issue #34).
+        args: [EXTRACTOR_SELECTORS, extractOnly],
       });
 
       await chrome.tabs.remove(tab.id);
@@ -820,7 +846,10 @@ async function _tabBasedExtractWithProgress(
 // Shared extractor function injected into tabs. MUST be self-contained (no closures,
 // no outer-scope refs) because executeScript serialises it into the page world. The
 // selector registry is passed in via `args` (structured clone) — see EXTRACTOR_SELECTORS.
-function _tabExtractorFunction(sel: ExtractorSelectors): { success: boolean; title?: string; content?: string; error?: string } {
+// `includeImages` appends X-article images as Markdown for the export path only
+// (issue #34). The import-as-text path passes false so raw `![](…)` never lands
+// in a NotebookLM text source. Bound to extractOnly at the executeScript sites.
+function _tabExtractorFunction(sel: ExtractorSelectors, includeImages: boolean): { success: boolean; title?: string; content?: string; error?: string } {
   const currentUrl = window.location.href;
   const firstMatch = (selectors: readonly string[]): Element | null => {
     for (const s of selectors) { const el = document.querySelector(s); if (el) return el; }
@@ -834,8 +863,29 @@ function _tabExtractorFunction(sel: ExtractorSelectors): { success: boolean; tit
       const titleEl = document.querySelector(sel.x.articleTitle);
       const title = titleEl?.textContent?.trim()
         || document.title.replace(/ \/ X$/, '').replace(/ on X:.*$/, '').trim();
-      const content = (xArticleContent as HTMLElement).innerText?.trim() || '';
-      if (content.length >= 100) return { success: true, title, content };
+      const text = (xArticleContent as HTMLElement).innerText?.trim() || '';
+      if (text.length >= 100) {
+        // Mirror of articleImagesMarkdown() in lib/extractors.ts — kept in sync;
+        // the fixture test is the tripwire. innerText drops <img>, so (export
+        // path only) append article images as URL-based Markdown that
+        // buildDocsHtml → PDF renders. Scoped to the captured article element so
+        // a quoted/embedded article's images can't leak in. Only pbs.twimg.com
+        // (excludes emoji/avatar images). Deduped.
+        let content = text;
+        if (includeImages) {
+          const seenSrc = new Set<string>();
+          const imgLines: string[] = [];
+          xArticleContent.querySelectorAll('img').forEach((img) => {
+            const src = img.getAttribute('src') || '';
+            if (!src.includes('pbs.twimg.com') || seenSrc.has(src)) return;
+            seenSrc.add(src);
+            const alt = (img.getAttribute('alt') || '').replace(/[[\]]/g, '').trim();
+            imgLines.push('![' + alt + '](' + src + ')');
+          });
+          if (imgLines.length) content = text + '\n\n' + imgLines.join('\n\n');
+        }
+        return { success: true, title, content };
+      }
     }
     const tweetTexts = document.querySelectorAll(sel.x.tweetText);
     if (tweetTexts.length > 0) {
@@ -934,7 +984,8 @@ async function _tabBasedExtract(
       const extractResult = await chrome.scripting.executeScript({
         target: { tabId: tab.id },
         func: _tabExtractorFunction,
-        args: [EXTRACTOR_SELECTORS],
+        // includeImages = extractOnly: images only on the export path (issue #34).
+        args: [EXTRACTOR_SELECTORS, extractOnly],
       });
 
       // Close the tab

--- a/lib/extractors.ts
+++ b/lib/extractors.ts
@@ -38,15 +38,51 @@ export function tweetTitle(doc: Document, docTitle: string, firstTweet: string |
   return author || snippet || 'X post';
 }
 
-export function extractX(doc: Document, docTitle: string, sel = X_SELECTORS): ExtractResult {
+/**
+ * Collect X Article body images as trailing Markdown. innerText/textContent
+ * drop <img>, so images would otherwise be lost from a PDF export. Emits
+ * URL-based Markdown (`![alt](src)`) that buildDocsHtml → marked renders as
+ * <img>; images load remotely when the PDF page prints (issue #34). Only
+ * pbs.twimg.com sources are kept — that excludes emoji/avatar images served
+ * from abs*.twimg.com. Deduped, in document order. Returns '' when none.
+ *
+ * Scoped to the passed article element (not the whole document) so a page with
+ * a second article container — e.g. an embedded/quoted article — can't leak its
+ * images into a body extracted from the first one.
+ */
+export function articleImagesMarkdown(article: Element): string {
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  article.querySelectorAll('img').forEach((img) => {
+    const src = img.getAttribute('src') || '';
+    if (!src.includes('pbs.twimg.com') || seen.has(src)) return;
+    seen.add(src);
+    const alt = (img.getAttribute('alt') || '').replace(/[[\]]/g, '').trim();
+    lines.push(`![${alt}](${src})`);
+  });
+  return lines.length ? '\n\n' + lines.join('\n\n') : '';
+}
+
+/**
+ * @param includeImages append article image Markdown (issue #34). Only the PDF/
+ *   clipboard export path passes true; the import-as-text path leaves it false so
+ *   raw `![](…)` syntax never lands in a NotebookLM text source (which doesn't
+ *   render Markdown). Mirrors the `includeImages` arg of _tabExtractorFunction.
+ */
+export function extractX(doc: Document, docTitle: string, sel = X_SELECTORS, includeImages = false): ExtractResult {
 
   // Long-form X Article
   const article = doc.querySelector(sel.articleContent);
   if (article) {
     const titleEl = doc.querySelector(sel.articleTitle);
     const title = titleEl?.textContent?.trim() || cleanTitle(docTitle);
-    const content = article.textContent?.trim() || '';
-    if (content.length >= 100) return { success: true, title, content };
+    const text = article.textContent?.trim() || '';
+    // Length gate is on the text body only, so appended image Markdown can't
+    // let an otherwise-empty article pass. Images are appended after the text.
+    if (text.length >= 100) {
+      const content = includeImages ? text + articleImagesMarkdown(article) : text;
+      return { success: true, title, content };
+    }
   }
 
   // Normal tweet / thread

--- a/lib/selectors.ts
+++ b/lib/selectors.ts
@@ -22,6 +22,10 @@
 export const X_SELECTORS = {
   /** Long-form "X Article" rich-text body. */
   articleContent: '[data-testid="twitterArticleRichTextView"]',
+  /** Content images inside a long-form article body. innerText/textContent drop
+   *  <img>, so images are extracted separately; callers filter to pbs.twimg.com
+   *  to keep article media and exclude emoji/avatars. */
+  articleImage: '[data-testid="twitterArticleRichTextView"] img',
   /** Long-form article title. */
   articleTitle: '[data-testid="twitter-article-title"]',
   /** Individual tweet body text (thread extraction joins these). */
@@ -92,6 +96,13 @@ export const MONITORED_SELECTORS: MonitoredSelector[] = [
     selector: X_SELECTORS.articleContent,
     minMatches: 1,
     notes: 'Long-form X Article body. Provide a current article URL as sample when auditing.',
+  },
+  {
+    site: 'x',
+    name: 'articleImage',
+    selector: X_SELECTORS.articleImage,
+    minMatches: 0,
+    notes: 'Content images inside an X Article body (pbs.twimg.com). minMatches 0 = an image-free article is still valid; canary only fails on selector-parse errors here.',
   },
   {
     site: 'notebooklm',

--- a/services/pdf-generator.ts
+++ b/services/pdf-generator.ts
@@ -148,6 +148,7 @@ h2 { font-family: "Noto Serif SC", serif; font-size: 1.4em; border-bottom: 1px s
 h3 { font-size: 1.2em; margin-top: 1.4em; color: #2a2420; }
 h4 { font-size: 1em; margin-top: 1.2em; color: #3a3430; }
 p { margin: .8em 0; }
+img { max-width: 100%; height: auto; margin: 1em 0; border-radius: 6px; }
 code { background: #eee8de; border-radius: 4px; padding: .15em .4em; font-size: 85%; font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; color: #5c4a3a; }
 pre { background: #eee8de; border-radius: 6px; padding: 16px; overflow-x: auto; line-height: 1.5; }
 pre code { background: none; padding: 0; }

--- a/tests/fixtures/x-article.html
+++ b/tests/fixtures/x-article.html
@@ -13,8 +13,12 @@
       <div data-testid="twitterArticleRichTextView">
         <p>Most developers first use coding agents for code: inspect a repository, make a change,
         run the tests. But the team behind Codex uses it for far more than writing code.</p>
+        <img src="https://pbs.twimg.com/media/Gabc123?format=jpg&name=medium" alt="Codex architecture diagram" />
         <p>This paragraph exists to push the extracted body comfortably past the 100-character
         minimum the extractor requires before it treats an article as successfully captured.</p>
+        <img src="https://pbs.twimg.com/media/Gabc123?format=jpg&name=medium" alt="Codex architecture diagram" />
+        <!-- Emoji image served from abs*.twimg.com must be excluded from extraction. -->
+        <img src="https://abs-0.twimg.com/emoji/v2/svg/1f600.svg" alt="grinning face" />
       </div>
     </article>
   </main>

--- a/tests/lib/extractors.test.ts
+++ b/tests/lib/extractors.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { extractX } from '@/lib/extractors';
+import { extractX, articleImagesMarkdown } from '@/lib/extractors';
 import { X_SELECTORS, NOTEBOOKLM_SELECTORS, MONITORED_SELECTORS } from '@/lib/selectors';
 
 const loadFixture = (name: string): Document => {
@@ -39,6 +39,61 @@ describe('X/Twitter selectors + extraction', () => {
     expect(result.title).toBe('来自 Codex 官方团队的分享：如何把 Codex 用到极致');
     expect(result.content).toContain('coding agents');
     expect(result.content!.length).toBeGreaterThanOrEqual(100);
+  });
+
+  it('appends X article images as Markdown when includeImages=true, deduped and pbs-only (issue #34)', () => {
+    const doc = loadFixture('x-article.html');
+    const result = extractX(doc, '', X_SELECTORS, true);
+
+    expect(result.success).toBe(true);
+    // pbs.twimg.com image is preserved as Markdown alongside the text body.
+    expect(result.content).toContain(
+      '![Codex architecture diagram](https://pbs.twimg.com/media/Gabc123?format=jpg&name=medium)',
+    );
+    // The same src appears twice in the fixture but must be emitted once.
+    const occurrences = result.content!.split('https://pbs.twimg.com/media/Gabc123').length - 1;
+    expect(occurrences).toBe(1);
+    // Emoji/avatar images from abs*.twimg.com are excluded.
+    expect(result.content).not.toContain('abs-0.twimg.com');
+    // Images come after the text body, not before it.
+    expect(result.content!.indexOf('coding agents')).toBeLessThan(
+      result.content!.indexOf('pbs.twimg.com'),
+    );
+  });
+
+  it('does NOT append image Markdown on the import-as-text path (includeImages defaults false)', () => {
+    // Guards the regression where raw ![](…) syntax leaked into NotebookLM text
+    // sources: the text-import path must get clean prose, images only in export.
+    const doc = loadFixture('x-article.html');
+    const result = extractX(doc, ''); // no includeImages → text only
+
+    expect(result.success).toBe(true);
+    expect(result.content).toContain('coding agents');
+    expect(result.content).not.toContain('pbs.twimg.com');
+    expect(result.content).not.toContain('![');
+  });
+
+  it('articleImagesMarkdown scopes to its article element and ignores a sibling container', () => {
+    const doc = new DOMParser().parseFromString(
+      `<div id="a" data-testid="twitterArticleRichTextView">
+         <img src="https://pbs.twimg.com/media/inA?format=jpg" alt="in A" />
+       </div>
+       <div id="b" data-testid="twitterArticleRichTextView">
+         <img src="https://pbs.twimg.com/media/inB?format=jpg" alt="in B" />
+       </div>`,
+      'text/html',
+    );
+    const md = articleImagesMarkdown(doc.querySelector('#a')!);
+    expect(md).toContain('pbs.twimg.com/media/inA');
+    expect(md).not.toContain('pbs.twimg.com/media/inB'); // sibling article's image excluded
+  });
+
+  it('articleImagesMarkdown returns empty string when an article has no images', () => {
+    const doc = new DOMParser().parseFromString(
+      '<div data-testid="twitterArticleRichTextView"><p>text only, no images here</p></div>',
+      'text/html',
+    );
+    expect(articleImagesMarkdown(doc.querySelector('[data-testid="twitterArticleRichTextView"]')!)).toBe('');
   });
 
   it('reports failure when no known selector matches (simulates an X UI change)', () => {


### PR DESCRIPTION
Closes #34

## 问题
X 长文(Article)导出 PDF 时,正文用 `innerText` 提取,`<img>` 被丢弃,配图全部丢失。

## 验收标准
- [x] X article 提取时保留 `<img src>`(pbs.twimg.com),随文本一并抓取
- [x] 图片以 URL Markdown(`![alt](src)`)进入 `buildDocsHtml`
- [x] 导出 PDF 中文章配图可见(集成验证:extractor → buildDocsHtml → `<img>` 渲染 ✓)
- [x] 沿用 `lib/selectors.ts` 的 `X_SELECTORS`(新增 `articleImage` 监控项);新增 img 提取不破坏纯文本回退

## 实现
- **`lib/extractors.ts`**:新增 `articleImagesMarkdown(article)`,收集 pbs.twimg.com 图片去重、拼成 Markdown;`extractX` 新增 `includeImages` 形参
- **`entrypoints/background.ts`**:`_tabExtractorFunction` 镜像同样逻辑(注入函数无法 import,靠 fixture 测试防漂移);`includeImages` 绑定到 `extractOnly`,两个 executeScript 注入点透传
- **`services/pdf-generator.ts`**:`buildDocsHtml` 加 `img { max-width:100%; height:auto }`,防止宽图溢出页面
- **图片加载同步**:新增 `cdpAwait`,`printToPDF` 前等待远程图片加载完成(封顶 5s),避免图片未加载就被截图为空白
- **`lib/selectors.ts`**:新增 `articleImage` 到 `X_SELECTORS` + `MONITORED_SELECTORS`(minMatches 0)
- **测试**:fixture 加入 pbs 图片(重复 + abs* emoji)+ 4 个新用例

## 测试结果
- `pnpm compile` ✅
- `pnpm test` ✅ 130 passed(+4 新增)
- `pnpm build` ✅
- 集成验证(node 跑真实 extractX → buildDocsHtml → marked 管线):
  - EXPORT 路径 `<img src="pbs.twimg.com...">` 正确渲染 ✅
  - IMPORT-as-text 路径无任何图片 Markdown 泄漏 ✅
  - emoji(abs-0.twimg.com)被排除 ✅
- 运行时全链路(登录态 X 文章 + 书签聚合导出 PDF + CDP 打印)需登录 X,无法在无头环境自动 /verify;可验证面(提取逻辑 + HTML 渲染 + CSS)已覆盖。

## 复核结论(/code-review high,workflow 版)
自审发现 1 CONFIRMED + 3 PLAUSIBLE,已处理:
1. ✅ **CONFIRMED** 图片 Markdown 泄漏到「导入为文本」路径(NotebookLM 文本源不渲染 Markdown)→ 用 `includeImages`(绑定 `extractOnly`)把图片限定在导出路径,并加回归测试守护
2. ✅ **PLAUSIBLE** `printToPDF` 固定 2s 等待、远程图片可能未加载完 → 新增图片加载等待(封顶 5s)
3. ✅ **PLAUSIBLE** 图片查询作用域为整个 document → 收窄到已捕获的 article 元素(加兄弟容器隔离测试)
4. ⚠️ **PLAUSIBLE(已文档化,不在本 PR 修)** X 懒加载导致折叠下方图片可能漏抓 → 作为已知限制写入 commit;部分抓取仍严格优于此前的零图片(彻底修需滚动提取 tab,涉及提取 tab 生命周期,超出本 issue 范围)
- 另有 1 项被复核判定为 refuted(img CSS 与 X 路径无关)——实际 X 导出走 buildDocsHtml,该 CSS 确有效,保留。

## 边界
仅改动 issue「涉及模块」列出的范围(X 提取注入脚本 / `lib/selectors.ts` / `services/pdf-generator.ts`)+ PDF 导出辅助函数,未触碰 NotebookLM 核心导入 DOM 流程。
